### PR TITLE
Added "Mozilla::CA" to as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Only perl is necessary plus the following non-default modules, which you can dow
 * `YAML`
 * `List::MoreUtils`
 * `File::Slurp`
+* `Mozilla::CA`
 
 
 Usage


### PR DESCRIPTION
In a fresh Perl env., the GitHub SSL cert isn't recognized.